### PR TITLE
Enhance module along the lines of ecs-service

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -2,10 +2,14 @@ data "aws_caller_identity" "current" {}
 
 module "get-subnets" {
   source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
-  count  = local.subnet_type != null ? 1 : 0
 
-  subnet_type = local.subnet_type
-  vpc         = local.vpc
+  count       = var.network_configuration.subnet_type != null ? 1 : 0
+  subnet_type = var.network_configuration.subnet_type
+  vpc         = var.network_configuration.vpc
+}
+
+locals {
+  module_subnet_ids = var.network_configuration.subnet_type != null ? try(module.get-subnets[0].subnets.ids, []) : []
 }
 
 data "aws_ecs_cluster" "selected" {


### PR DESCRIPTION
*   Network configuration block is now an object with validation rules, as with ecs-service.

*   Eliminate superfluous local variables now no longer needed given that objects now have sane defaults, and can be referenced as dotted variables rather than using lookup().

*   Use null values to be consistent with ecs-service.

*   Collapse two task definition resources (one for fargate and one for ec2) into a single default resource.

*   Add validation of launch type (as in ecs-service).

*   Validate subnet_type.

*   Add _debug variable.

*   Update documentation.