### PR TITLE
Change is_enabled to state

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Argument Reference
 
 * `desired_count` - The number of instances of the task definition to place and keep  running. (Default = `1`)
 
-* `is_enabled` - Whether the rule should be enabled (Default = `true`).
+* `state` - State of the rule, valid options are ENABLED, ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS, or DISABLED. (Default = `ENABLED`)
 
 * `launch_type` - The launch type on which to run the service. The valid values are EC2 and FARGATE. (Default = `FARGATE`)
 
@@ -247,7 +247,7 @@ Attributes Reference
 
 The following attributes are exported:
 
-* `is_enabled` – Is the task enabled.
+* `state` – Is the task enabled.
 
 * `name` - The name of the scheduled task.
 

--- a/main.tf
+++ b/main.tf
@@ -43,7 +43,7 @@ resource "aws_ecs_task_definition" "default" {
 }
 
 resource "aws_cloudwatch_event_rule" "default" {
-  is_enabled          = var.is_enabled
+  state               = var.state
   name                = var.name
   schedule_expression = var.schedule_expression
   tags                = local.tags

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,6 +10,6 @@ output "schedule_expression" {
   value = aws_cloudwatch_event_rule.default.schedule_expression
 }
 
-output "is_enabled" {
-  value = aws_cloudwatch_event_rule.default.is_enabled
+output "state" {
+  value = aws_cloudwatch_event_rule.default.state
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,9 +8,15 @@ variable "desired_count" {
   default     = 1
 }
 
-variable "is_enabled" {
-  description = "Whether the rule should be enabled (defaults to true)."
-  default     = true
+variable "state" {
+  description = "State of the rule, valid options are ENABLED (default), ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS, or DISABLED."
+  default     = "ENABLED"
+
+  validation {
+    condition = try(contains(["ENABLED", "ENABLED_WITH_ALL_CLOUDTRAIL_MANAGEMENT_EVENTS", "DISABLED"],
+    var.state), true)
+    error_message = "The 'state' is not one of the valid values."
+  }
 }
 
 variable "launch_type" {


### PR DESCRIPTION
AWS has updated the Terraform event rule module (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule). The is_enabled input has been replaced with state. Here's a change adding that to our module so we don't get deprocation warnings. Since this replaces a boolean is_enabled with a string for state, it should be considered a significant version bump.