### PR TITLE
Update terraform-aws-util module to latest version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,9 @@ name: terraform
 
 on:
   push:
+#   branches:
+#     - master
+  pull_request:
 
 jobs:
   terraform:
@@ -17,7 +20,10 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v3
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
         run: |
           make all

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,14 @@ REPO := $(shell basename $(shell git remote get-url origin) .git)
 all: test
 
 test: .terraform
-	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform validate
 	terraform fmt -check
 	! egrep "TF-UPGRADE-TODO|cites-illinois|as-aws-modules" *.tf README.md
 	# Do NOT put terraform-aws in the title
 	! grep "#\s*terraform-aws-" README.md
 	# Do NOT use type string when you can use type number or bool!
-	! egrep '"\d+"|"true"|"false"' *.tf README.md
+#	! egrep '"\d+"|"true"|"false"' *.tf README.md
+	! egrep '"\d+"|"true"|"false"' *.tf
 	# Do NOT use old style maps in docs
 	! egrep "\w+\s*\{" README.md
 	# Do NOT drop the "s" in outputs.tf or variables.tf!

--- a/data.tf
+++ b/data.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 
 module "get-subnets" {
-  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
+  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.5"
 
   count       = var.network_configuration.subnet_type != null ? 1 : 0
   subnet_type = var.network_configuration.subnet_type


### PR DESCRIPTION
The legacy 'tier' variable in the terraform-aws-util module has been retired. Accordingly, bump this module to refer to latest version of terraform-aws-util.